### PR TITLE
Data serialization fix

### DIFF
--- a/IpcStream.cs
+++ b/IpcStream.cs
@@ -126,8 +126,8 @@ namespace EasyPipes
                 if (length > UInt16.MaxValue)
                     throw new InvalidOperationException("Message is too long");
 
-            // write message length
-            BaseStream.Write(new byte[] { (byte)(length / 256), (byte)(length & 255) }, 0, 2);
+                // write message length
+                BaseStream.Write(new byte[] {(byte) (length / 256), (byte) (length % 256)}, 0, 2);
 
                 // write message
                 BaseStream.Write(buffer, 0, length);

--- a/IpcStream.cs
+++ b/IpcStream.cs
@@ -33,6 +33,7 @@ namespace EasyPipes
 
         private bool _disposed = false;
         protected bool encrypted = false;
+        private object _lockObject = new object();
 
         /// <summary>
         /// Constructor
@@ -119,16 +120,19 @@ namespace EasyPipes
         /// <param name="buffer">byte buffer</param>
         protected void WriteBytes(byte[] buffer)
         {
-            int length = buffer.Length;
-            if (length > UInt16.MaxValue)
-                throw new InvalidOperationException("Message is too long");
+            lock (_lockObject)
+            {
+                int length = buffer.Length;
+                if (length > UInt16.MaxValue)
+                    throw new InvalidOperationException("Message is too long");
 
             // write message length
             BaseStream.Write(new byte[] { (byte)(length / 256), (byte)(length & 255) }, 0, 2);
 
-            // write message
-            BaseStream.Write(buffer, 0, length);
-            BaseStream.Flush();
+                // write message
+                BaseStream.Write(buffer, 0, length);
+                BaseStream.Flush();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, the KeepAlive pings could cause serialization errors by injecting data in-between a write header and payload.  This would cause the receiving reader to receive data that was prefixed by the Ping's size header and exception.


By ensuring that only one thread has access to the writer at a time, we can eliminate this risk and ensure the integrity of Header/Payload pairs.

I also changed the second size header byte to be a modulus operation.  Even over millions of iterations, modern compiled modulus is still approximately the same performance.  That said, however, there was nothing wrong with the previous calculation, I just find modulus to be more clear in intent.  