### PR TITLE
Disconnect handler

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -157,7 +157,15 @@ namespace EasyPipes
             timer = new Timer(
                 (object state) =>
                 {
-                    SendMessage(new IpcMessage { StatusMsg = StatusMessage.Ping });
+                    try
+                    {
+                        SendMessage(new IpcMessage { StatusMsg = StatusMessage.Ping });
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        this.Disconnect(false);
+                    }
                 },
                 null,
                 Server.ReadTimeOut / 2,

--- a/Client.cs
+++ b/Client.cs
@@ -80,6 +80,8 @@ namespace EasyPipes
         /// </summary>
         public List<Type> KnownTypes { get; private set; }
 
+        public Action WhenDisconnected { get; set; }
+        
         protected Timer timer;
 
         /// <summary>
@@ -224,6 +226,7 @@ namespace EasyPipes
                 Stream.Dispose();
 
             Stream = null;
+            WhenDisconnected?.Invoke();
         }
     }
 }

--- a/Client.cs
+++ b/Client.cs
@@ -210,6 +210,9 @@ namespace EasyPipes
         /// to the server (if you called Connect(), this should be true)</param>
         public virtual void Disconnect(bool sendCloseMessage = true)
         {
+            // stop keepalive ping
+            timer?.Dispose();
+            
             // send close notification
             if (sendCloseMessage)
             {

--- a/Client.cs
+++ b/Client.cs
@@ -216,11 +216,8 @@ namespace EasyPipes
             // send close notification
             if (sendCloseMessage)
             {
-                // stop keepalive ping
-                timer?.Dispose();
-
                 IpcMessage msg = new IpcMessage() { StatusMsg = StatusMessage.CloseConnection };
-                Stream.WriteMessage(msg);
+                Stream?.WriteMessage(msg);
             }
 
             if (Stream != null)


### PR DESCRIPTION
This modifies the disconnect behavior of a Client in the following ways:

* adds a WhenDisconnected event that allows the creator to react to the Server closing.
* KeepAlive pings are stopped, rather than only stopping if a disconnect message is sent to the Server.
* An Exception is prevented if Disconnect is called when the Connect did not succeed.  (also required if the last bullet is accepted)
* A KeepAlive ping failure is caught and treated as a Server disconnect, rather than bubbling the exception on the Timer.